### PR TITLE
automatic releases on each push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,27 @@
 name: publish
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
 
 jobs:
   pypi:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set Package Version
+        run: |
+          pip install poetry
+          poetry version "`poetry version -s`.$GITHUB_RUN_NUMBER"
+
       - name: Publish to PyPI (via Poetry)
         uses: JRubics/poetry-publish@v1.17
         with:
-          # NOTE: this secret should be added for the entire Rippling org, but is currently a repository secret
           pypi_token: ${{ secrets.PYPI_TOKEN }}
+
+          # NOTE: un-comment the configuration below to publish to Test PyPI instead
+          # pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}
+          # repository_name: testpypi
+          # repository_url: https://test.pypi.org/legacy/

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -2,26 +2,9 @@
 
 ## Publishing New Releases
 
-First, create a new release branch, using the naming convention "release/<new version>" (eg: "release/0.1.1"):
+Each merge to the `main` branch will create a new release using the format `<major>.<minor>.<build number>`.
 
-```shell
-git checkout -b release/0.1.1
-```
+The `<major>` and `<minor>` need to be updated in any PR which introduces changes beyond simply bug fixes. If the change
+is not backwards-compatible, bump "major". Otherwise (this should be most of the time), bump "minor".
 
-Next, determine which semver level (patch/minor/major) to bump.  Then, execute the following in your release branch:
-
-```shell
-poetry version <patch|minor|major>
-```
-
-Which will update `pyproject.toml` and print the new version:
-
-> Bumping version from 0.1.0 to 0.1.1
-
-Commit this change and open a Pull Request with your branch. Once approved and merged, create a new release using the
-GitHub Releases UI:
-- tag: create a new tag using the new version (eg: "0.1.1")
-- title: "Release <new version>" (eg: "Release 0.1.1")
-- description: click "Generate release notes" to allow GitHub to automate this
-
-Once published, a GitHub Actions workflow will take care of publishing the new release to PyPI.
+The `<build number>` is an always-increasing number from the "publish" GitHub Actions workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rippling-flux-dev-tools"
-version = "0.0.2"
+version = "0.1"
 description = "Rippling Flux App development tools."
 authors = ["Rippling Apps <apps@rippling.com>"]
 readme = "README.md"


### PR DESCRIPTION
This PR updates the release process to be more automatic:
 - each push to `main` will publish to PyPI
 - the semver "major" and "minor" will come from `pyproject.toml` while the "patch" will come from `github.run_number`