### PR TITLE
security: harden publish workflow — remove third-party action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,23 +5,27 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set Package Version
         run: |
           pip install poetry
           poetry version "`poetry version -s`.$GITHUB_RUN_NUMBER"
 
-      - name: Publish to PyPI (via Poetry)
-        uses: JRubics/poetry-publish@v1.17
-        with:
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: poetry publish --build
 
-          # NOTE: un-comment the configuration below to publish to Test PyPI instead
-          # pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}
-          # repository_name: testpypi
-          # repository_url: https://test.pypi.org/legacy/
+        # NOTE: to publish to Test PyPI instead, replace the env and run above with:
+        # env:
+        #   POETRY_REPOSITORIES_TESTPYPI_URL: https://test.pypi.org/legacy/
+        #   POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TEST_PYPI_TOKEN }}
+        # run: poetry publish --build -r testpypi


### PR DESCRIPTION
## Summary

- Removes third-party `JRubics/poetry-publish` action which received `PYPI_TOKEN` via a tag-pinned reference (`@v1.17`). This is a supply chain risk — if the upstream tag is force-pushed, our PyPI token is exposed to arbitrary code.
- Replaces it with a direct `poetry publish --build` command using the `POETRY_PYPI_TOKEN_PYPI` env var. Same functionality, zero third-party dependency.
- Pins `actions/checkout` to full commit SHA (`v4`).
- Adds explicit `permissions: contents: read` to limit the workflow token scope.

## Test plan

- [x] I acknowledge the risks of shipping a PR without a test plan.

The workflow only runs on push to `main`. Verify the next publish to PyPI succeeds after merge.

## Rollback plan

- [x] Check this box if this PR can be safely reverted.

Reverting restores the previous `JRubics/poetry-publish` action. Publishing will continue to work either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change isolated to CI publishing: it replaces a third-party publish action with a direct `poetry publish` command and tightens workflow token permissions; main risk is publish failures if Poetry auth env vars differ from expectations.
> 
> **Overview**
> Hardens the PyPI publish GitHub Actions workflow by adding explicit `permissions: contents: read` and pinning `actions/checkout` to a specific v4 commit SHA.
> 
> Replaces the `JRubics/poetry-publish` third-party action with a direct `poetry publish --build` step that passes the token via `POETRY_PYPI_TOKEN_PYPI` (and updates the inline TestPyPI guidance accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7249b67ad7843966306cf679c935634c59eef3c7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->